### PR TITLE
Bump minimist and mkdirp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2342,11 +2342,6 @@
                                 "brace-expansion": "^1.1.7"
                             }
                         },
-                        "minimist": {
-                            "version": "0.0.8",
-                            "bundled": true,
-                            "optional": true
-                        },
                         "minipass": {
                             "version": "2.3.5",
                             "bundled": true,
@@ -2362,14 +2357,6 @@
                             "optional": true,
                             "requires": {
                                 "minipass": "^2.2.1"
-                            }
-                        },
-                        "mkdirp": {
-                            "version": "0.5.1",
-                            "bundled": true,
-                            "optional": true,
-                            "requires": {
-                                "minimist": "0.0.8"
                             }
                         },
                         "ms": {
@@ -2494,13 +2481,6 @@
                                 "ini": "~1.3.0",
                                 "minimist": "^1.2.0",
                                 "strip-json-comments": "~2.0.1"
-                            },
-                            "dependencies": {
-                                "minimist": {
-                                    "version": "1.2.0",
-                                    "bundled": true,
-                                    "optional": true
-                                }
                             }
                         },
                         "readable-stream": {
@@ -5560,12 +5540,6 @@
                         "brace-expansion": "^1.1.7"
                     }
                 },
-                "minimist": {
-                    "version": "0.0.8",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
                 "minipass": {
                     "version": "2.3.5",
                     "bundled": true,
@@ -5583,15 +5557,6 @@
                     "optional": true,
                     "requires": {
                         "minipass": "^2.2.1"
-                    }
-                },
-                "mkdirp": {
-                    "version": "0.5.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "minimist": "0.0.8"
                     }
                 },
                 "ms": {
@@ -5732,14 +5697,6 @@
                         "ini": "~1.3.0",
                         "minimist": "^1.2.0",
                         "strip-json-comments": "~2.0.1"
-                    },
-                    "dependencies": {
-                        "minimist": {
-                            "version": "1.2.0",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        }
                     }
                 },
                 "readable-stream": {
@@ -7631,10 +7588,9 @@
             }
         },
         "minimist": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-            "dev": true
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+            "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
         },
         "mississippi": {
             "version": "3.0.0",
@@ -7697,20 +7653,11 @@
             }
         },
         "mkdirp": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-            "dev": true,
+            "version": "0.5.6",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+            "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
             "requires": {
-                "minimist": "0.0.8"
-            },
-            "dependencies": {
-                "minimist": {
-                    "version": "0.0.8",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-                    "dev": true
-                }
+                "minimist": "^1.2.6"
             }
         },
         "move-concurrently": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4426,13 +4426,10 @@ minimatch@^3.0.2, minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
-
-minimist@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
+minimist@^1.2.0, minimist@^1.2.6:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
+  integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
 minipass@^2.2.1, minipass@^2.3.5:
   version "2.3.5"
@@ -4487,10 +4484,11 @@ mixin-object@^2.0.1:
     is-extendable "^0.1.1"
 
 mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.6.tgz#7def03d2432dcae4ba1d611445c48396062255f6"
+  integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
   dependencies:
-    minimist "0.0.8"
+    minimist "^1.2.6"
 
 move-concurrently@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Bumps [minimist](https://github.com/minimistjs/minimist) and [mkdirp](https://github.com/isaacs/node-mkdirp). These dependencies needed to be updated together.

Updates `minimist` from 1.2.0 to 1.2.8
- [Release notes](https://github.com/minimistjs/minimist/releases)
- [Changelog](https://github.com/minimistjs/minimist/blob/main/CHANGELOG.md)
- [Commits](https://github.com/minimistjs/minimist/compare/v1.2.0...v1.2.8)

Updates `mkdirp` from 0.5.1 to 0.5.6
- [Release notes](https://github.com/isaacs/node-mkdirp/releases)
- [Changelog](https://github.com/isaacs/node-mkdirp/blob/main/CHANGELOG.md)
- [Commits](https://github.com/isaacs/node-mkdirp/compare/0.5.1...v0.5.6)

---
updated-dependencies:
- dependency-name: minimist dependency-type: indirect
- dependency-name: mkdirp dependency-type: indirect ...